### PR TITLE
Changed aerial sakurai angle from 44 degrees to 45 degrees

### DIFF
--- a/calculatormaths.js
+++ b/calculatormaths.js
@@ -181,7 +181,7 @@ function Hit(percent, damagestaled, damageunstaled, growth, base, setKnockback, 
               }
               sakurai = 0;
             }
-            else if (knockback >= 32.1 || !grounded) {
+            else if (knockback >= 32.1 && grounded) {
               if (reverse){
                 traj = 136;
               }
@@ -191,7 +191,7 @@ function Hit(percent, damagestaled, damageunstaled, growth, base, setKnockback, 
               }
               sakurai = 44;
             }
-            else {
+            else if (grounded) {
               prompt("Why would this ever get called?");
               traj = 440*(knockback-32);
               if (reverse){
@@ -201,6 +201,16 @@ function Hit(percent, damagestaled, damageunstaled, growth, base, setKnockback, 
                   }
               }
             }
+            else {
+              if (reverse) {
+                traj = 135;
+              }
+              else {
+                traj = 45;
+                trajectory = 45;
+              }
+              sakurai = 45;
+          }
         }
         else {
           if (reverse){


### PR DESCRIPTION
I checked [smashwiki](https://www.ssbwiki.com/Sakurai_angle) and in-game, and sakurai angles in the air have 45 degree knockback. The current handling lumps it in with high-knockback grounded at 44 degrees. I modified the elif chain to separate out aerial hits and give it the proper angle